### PR TITLE
Update .gitignore for VSCode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ out/
 *.ipr
 *.iws
 
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
 # fabric
 
 run/


### PR DESCRIPTION
Updates the `.gitignore` to support VSCode.

Ignores files that are autogenerated upon opening VSCode as well as the `bin` folder where builds are output.

Closes #5 