### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.14.2
-	yarn_mappings=1.14.2+build.1
+	yarn_mappings=1.14.2+build.7
 	loader_version=0.4.8+build.154
 
 # Mod Properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric
-	fabric_version=0.3.0+build.170
+	fabric_version=0.3.0+build.176


### PR DESCRIPTION
Updated mappings and API version.
API build 170, which it was set to previously, has the big issue where block loot tables are broken. I've seen multiple modders complaining of this issue in the Fabric discord, which can simply be fixed by updating the API version, so I felt it was best if the example mod was updated so people don't run into the issue in future.
I updated the mappings because I may as well.