### PR TITLE
Bumped fabric-loom 0.2.6-SNAPSHOT to 0.2.7-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.2.6-SNAPSHOT'
+	id 'fabric-loom' version '0.2.7-SNAPSHOT'
 	id 'maven-publish'
 }
 


### PR DESCRIPTION
Changed the version number in build.gradle so it can just update it the next time gradlew is run.