### PR TITLE
Add minVersion to template mixin config

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.7.2",
+    "fabricloader": ">=0.7.4",
     "fabric": "*",
     "minecraft": "1.15.x"
   },

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -1,5 +1,6 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "net.fabricmc.example.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [


### PR DESCRIPTION
As per a discussion on Spongecord with Mumfrey he noticed the obvious lack of a `minVersion` element within the Mixin config included in the template mod and reccomended the addition of one. Of course since loader 0.7+ uses mixin 0.8, the default `minVersion` is set to `0.8`