### PR TITLE
Add Mac OS metadata files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,14 @@ bin/
 # fabric
 
 run/
+
+# mac os
+.DS_Store # Folder Info
+.Trashes # Files to be deleted
+.AppleDouble # File System Fork
+Icon? # Folder icon
+._* # Thumbnail fikes
+.Spotlight-V100 # File System Indexer
+.fseventsd # File System Info
+.TemperoryItems # Temperory Items
+Thumbs.db # Random generated file


### PR DESCRIPTION
Add every single Mac OS metadata file from OS X 10.11 to Mac OS 10.15