### PR TITLE
Set build mode to IntelliJ by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'fabric-loom' version '0.2.7-SNAPSHOT'
 	id 'maven-publish'
+	id 'org.jetbrains.gradle.plugin.idea-ext' version '0.7'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -73,5 +74,12 @@ publishing {
 	repositories {
 		// uncomment to publish to the local maven
 		// mavenLocal()
+	}
+}
+
+idea.project.settings {
+	delegateActions {
+		delegateBuildRunToGradle = false
+		testRunner = org.jetbrains.gradle.ext.ActionDelegationConfig.TestRunner.PLATFORM
 	}
 }


### PR DESCRIPTION
This sets the build mode to IntelliJ instead of Gradle by default, which improves build times because it will no longer call Gradle to compile and fixes hotswap related issues such as hotswap not working at all (like showing the "method not implemented" error indicating that it tried to hotswap something that the default implementation couldn't hotswap, even though it should work without any problem) or reloading every class on every hotswap.