### PR TITLE
Best practice for constructor injection, clearer mixins.json template

### DIFF
--- a/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
+++ b/src/main/java/net/fabricmc/example/mixin/ExampleMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
 public class ExampleMixin {
-	@Inject(at = @At("HEAD"), method = "init()V")
+	@Inject(at = @At("RETURN"), method = "init()V")
 	private void init(CallbackInfo info) {
 		System.out.println("This line is printed by an example mod mixin!");
 	}

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -4,9 +4,11 @@
   "package": "net.fabricmc.example.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "ExampleMixin"
   ],
   "client": [
-    "ExampleMixin"
+  ],
+  "server": [
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Injections at the HEAD of constructors can cause issues, it's surprising it compiled the way it was. 
- Moved ExampleMixin to "mixins" because that's likely where most developers will need their mixin, and added "server": [] for completeness and to show all three possibilities. 