### PR TITLE
Updated For Use With Loom 0.5-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ bin/
 # fabric
 
 run/
+
+# OSX
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+	id 'fabric-loom' version '0.5-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.3
-	yarn_mappings=1.16.3+build.1
+	yarn_mappings=1.16.3+build.7
 	loader_version=0.9.3+build.207
 
 # Mod Properties

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,5 +6,6 @@ pluginManagement {
             url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
Currently due to this bug, https://github.com/FabricMC/fabric-loom/issues/280, I've added mavenCentral to the repository list. I've also added .DS_Store files from Mac OSX to the .gitignore list as there's no reason anyone would want folder setting files from Mac to be in their repo.