### PR TITLE
Simply processResources logic & make it compatible with future versions of Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ bin/
 .classpath
 .project
 
+# macos
+
+*.DS_Store
+
 # fabric
 
 run/

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 processResources {
 	inputs.property "version", project.version
 
-	filesMatching('fabric.mod.json') {
+	filesMatching("fabric.mod.json") {
 		expand "version": project.version
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,8 @@ dependencies {
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
+	filesMatching('fabric.mod.json') {
 		expand "version": project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
 	}
 }
 


### PR DESCRIPTION
When the processResources task is currently run, it uses deprecated Gradle features. Running "gradle clean build --warning-mode all" on this example project should output a message along the lines of "Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0.". This is due to the build script currently including all files twice. Gradle includes the resources directory by default, and the build script includes it again with the "from" block. This PR simply uses "filesMatching" to instead select the relevant files from the already included resources directory, leaving all other resources unmodified but still included in the output of the task. This also reduces the amount of repetition in the script, and helps with reducing human error (e.g. changing only one "from" block to the new desired behaviour).

This PR also includes an edit to the .gitignore to ignore commonly generated Mac OS junk files. This is optional, but would be a huge quality of life improvement for anyone developing on Mac OS, as the first thing I do when starting a new project is always to add this to the .gitignore. Example: Just from the small changes I've made to the build script alone, I've generated 4 .DS_Store files, which would clutter up this PR if I included them.