### PR TITLE
Improve description of repositories blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ publishing {
     // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
     repositories {
         // Add repositories to publish to here.
-        // Notice: This block does NOT have the same function as the block in line 13.
+        // Notice: This block does NOT have the same function as the block in the top level.
         // The repositories here will be used for publishing your artifact, not for
         // retrieving dependencies.
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,9 @@ group = project.maven_group
 
 repositories {
     // Add repositories to retrieve artifacts from in here.
-    // Loom adds the Fabric maven automatically so you don't
-    // have to. See https://docs.gradle.org/current/userguide/declaring_repositories.html
+    // You should only use this when depending on other mods because
+    // Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+    // See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,6 @@ publishing {
         // Add repositories to publish to here.
         // Notice: This block does NOT have the same function as the block in line 13.
         // The repositories here will be used for publishing your artifact, not for
-        // retirieving dependencies.
+        // retrieving dependencies.
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    // Add repositories to retrive artifacts from in here.
+    // Add repositories to retrieve artifacts from in here.
     // Loom adds the Fabric maven automatically so you don't
     // have to. See https://docs.gradle.org/current/userguide/declaring_repositories.html
     // for more information about repositories.

--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,6 @@ publishing {
 			}
 		}
 	}
-
-	// Select the repositories you want to publish to
-	// To publish to maven local, no extra repositories are necessary. Just use the task `publishToMavenLocal`.
-	repositories {
-		// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
-	}
+    
+    // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,13 @@ archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
+repositories {
+    // Add repositories to retrive artifacts from in here.
+    // Loom adds the Fabric maven automatically so you don't
+    // have to. See https://docs.gradle.org/current/userguide/declaring_repositories.html
+    // for more information about repositories.
+}
+
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -75,4 +82,10 @@ publishing {
 	}
     
     // See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+    repositories {
+        // Add repositories to publish to here.
+        // Notice: This block does NOT have the same function as the block in line 13.
+        // The repositories here will be used for publishing your artifact, not for
+        // retirieving dependencies.
+    }
 }


### PR DESCRIPTION
The `repositories` block inside the maven publish configuration does *nothing* but confuse new modders who want to use libraries.

~~If someone wants to publish their project to a maven repository, they probably know what they're doing and can figure out adding three lines of code.~~

This PR aims to fix that by adding another dependencies stub and improving the comments.