### PR TITLE
Remove unnecessary GitHub Actions step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
       - name: capture build artifacts


### PR DESCRIPTION
"make gradle wrapper executable" is unnecessary because the file already has the executable bit set in the repository.