### PR TITLE
Use UTF-8 instead of system default encoding for processResources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,11 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.release = 16
 }
 
+tasks.withType(AbstractCopyTask).configureEach {
+	// ensures processResources uses UTF-8 instead of the system default encoding
+	it.filteringCharset = "UTF-8"
+}
+
 java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.


### PR DESCRIPTION
Similar to how the `JavaCompile` encoding is set to UTF-8, this will set the `filteringCharset` for `processResources` (and potentially other CopyTasks) to UTF-8 as well.

This fixes some issues with Unicode handling for the fabric.mod.json on Windows at least.
Here's an example before and after:
![windows-1252](https://user-images.githubusercontent.com/8464472/141100212-e038d803-0114-446a-85c9-8d20b9cb20d2.png)
![UTF-8](https://user-images.githubusercontent.com/8464472/141100215-9a881e5e-be65-462d-a847-c8cf461bc87d.png)
 