### PR TITLE
Update fabric latest versions link

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/versions.html
+	# check these on https://fabricmc.net/develop
 	minecraft_version=1.18.1
 	yarn_mappings=1.18.1+build.1
 	loader_version=0.12.12


### PR DESCRIPTION
The [old page](https://fabricmc.net/versions.html) is missing links to the online javadocs. It tells users to use the [new page](https://fabricmc.net/develop) instead, so we might as well provide the new one here to begin with.