### PR TITLE
Add files the JVM may generate under certain conditions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ bin/
 # fabric
 
 run/
+
+# java
+
+hs_err_*.log
+replay_*.log
+*.hprof
+*.jfr


### PR DESCRIPTION
You probably know hs_err_pid*.log files already (they are JVM crashes or generally crashes in native code). Sometimes, the JVM will also generate replay_pid*.log or *.jfr files along them (with further debugging information). 
The *.hprof files are heap dumps, I'm not entirely sure if JVM crashes can generate them on default settings, but ignoring them can't harm, can it?