### PR TITLE
Update Gradle version and Fabric dependencys

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.19.3
-	yarn_mappings=1.19.3+build.1
-	loader_version=0.14.11
+	yarn_mappings=1.19.3+build.5
+	loader_version=0.14.14
 
 # Mod Properties
 	mod_version = 1.0.0
@@ -14,4 +14,4 @@ org.gradle.parallel=true
 	archives_base_name = fabric-example-mod
 
 # Dependencies
-	fabric_version=0.68.1+1.19.3
+	fabric_version=0.73.0+1.19.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 8.0 released, so I test example mod on Gradle 8.0
No build error, works fine on Minecraft.
And the mod targeted 1.19.3 so I updated Fabric dependencys(Loader,API,yarn).
I hope this commit intergrate on this project.
