### PR TITLE
Update build script to support Gradle 9 / fix deprecations added in 8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${base.archivesName}"}
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,6 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
@@ -33,6 +29,10 @@ dependencies {
 	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
 }
 
+base {
+	archivesName = project.archives_base_name
+}
+
 processResources {
 	inputs.property "version", project.version
 
@@ -51,6 +51,9 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${base.archivesName}"}
+		rename { "${it}_${base.archivesName.get()}"}
 	}
 }
 


### PR DESCRIPTION
As of recent Gradle 8.2 nightlys using plugin conventions have been deprecated and now raise a warning when building. This PR moves to the replacement in preperation for Gradle 9.

See:

https://github.com/gradle/gradle/blob/6ac87a4aa8756b70c74bc08d3b7156112ff81f61/subprojects/docs/src/docs/userguide/migration/upgrading_version_8.adoc#deprecated-access-to-plugin-conventions

and

https://github.com/gradle/gradle/pull/24231
