### PR TITLE
fix newlines being expanded in fabric.mod.json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,9 @@ processResources {
 	inputs.property "version", project.version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version
+		expand("version": project.version) {
+			escapeBackslash = true
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes the previous erroneous behaviour, in which the \n in the JSON string was being expanded to a literal line feed character, causing the JSON file to be invalid since escape characters are not allowed inside JSON strings, and must be escaped.

Relevant documentation: https://docs.gradle.org/current/javadoc/org/gradle/api/file/ContentFilterable.html#expand-java.util.Map-org.gradle.api.Action-

I gave more rationale and examples of before and after this fix in this PR: https://github.com/dzwdz/chat_heads/pull/43