### PR TITLE
Make datagen setup use fabricApi { 	configureDataGeneration() } to match mod template generator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ loom {
 
 }
 
+fabricApi {
+	configureDataGeneration()
+}
+
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"


### PR DESCRIPTION
This PR makes datagen setup use fabricApi { 	configureDataGeneration() } to match mod template generator