### PR TITLE
Set `escapeBackslash` for `fabric.mod.json` variable expansion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,9 @@ processResources {
 	inputs.property "version", project.version
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version
+		expand("version": project.version) {
+			escapeBackslash = true
+		}
 	}
 }
 


### PR DESCRIPTION
The file seems to be parsed in some capacity, as without this change, the sequence `\n` (just in the file, not even in the interpolated variable) is replaced with a literal newline, which by the JSON spec isn't allowed in strings.