### PR TITLE
Added .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ classes/
 .vscode/
 bin/
 .classpath
+.factorypath
 .project
 
 # macos


### PR DESCRIPTION
Since I've been using Java 21, opening a project in VsCode generates a `.factorypath` file at the root of the project, which should be ignored by version control. (This also applies to older version of minecraft.)

Is this repo used by the [online template generator](https://fabricmc.net/develop/template/) ? I'd like the change to be reflected here too.