### PR TITLE
Use modern kotlin dsl build scripts instead of the groovy ones

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,8 @@
 pluginManagement {
 	repositories {
 		maven {
-			name = 'Fabric'
-			url = 'https://maven.fabricmc.net/'
+			name = "Fabric"
+			url = uri("https://maven.fabricmc.net/")
 		}
 		mavenCentral()
 		gradlePluginPortal()


### PR DESCRIPTION
In Gradle the Kotlin dsl build scripts are the default instead of groovy. See https://blog.gradle.org/kotlin-dsl-is-now-the-default-for-new-gradle-builds.

Therefore the template should also use kotlin dsl.