### PR TITLE
Add a Loom property to gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
+	id 'fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -37,7 +37,7 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 	
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ org.gradle.parallel=true
 minecraft_version=1.21.5
 yarn_mappings=1.21.5+build.1
 loader_version=0.16.10
+loom_version=1.10-SNAPSHOT
 
 # Mod Properties
 mod_version=1.0.0
@@ -14,4 +15,4 @@ maven_group=com.example
 archives_base_name=modid
 
 # Dependencies
-fabric_version=0.119.5+1.21.5
+fabric_api_version=0.119.5+1.21.5


### PR DESCRIPTION
This PR adds a `loom_version` property to `gradle.properties` that is used in the `plugins` block. This puts the Loom version in a more centralised place for easier accessibility. While I was at it I renamed `fabric_version` to `fabric_api_version`.