### PR TITLE
Use setup-gradle over wrapper-validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
-      - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
       - name: setup jdk
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'microsoft'
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v5
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build


### PR DESCRIPTION
setup-gradle already performs wrapper-validation as part of its lifecycle. https://github.com/gradle/actions?tab=readme-ov-file#the-wrapper-validation-action

Also bumped version of it to v5.

The setup-gradle action adds a nice build summary plus keeps gradle build cache and dependencies saved automatically, reducing CI build times.

Let me know if any other changes are needed or additional PRs for other version branches are needed. Judging by the last commit dates I assume 1.21 branch is the only one actively supported.